### PR TITLE
Fix estimator printing out nans

### DIFF
--- a/thermal_soaring/src/thermal_estimator.cpp
+++ b/thermal_soaring/src/thermal_estimator.cpp
@@ -25,6 +25,8 @@ ThermalEstimator::ThermalEstimator(const ros::NodeHandle& nh, const ros::NodeHan
   Q_vector << 1.0, 1.0, 1.0, 1.0;
   Q_ = Q_vector.asDiagonal();
 
+  thermal_state_ << 100.0, 10.0, 0.0, 0.0;
+
   status_pub_ = nh_.advertise<soaring_msgs::ThermalEstimatorStatus>("/soaring/thermal_estimator/status", 1);
 }
 

--- a/thermal_soaring/src/thermal_soaring.cpp
+++ b/thermal_soaring/src/thermal_soaring.cpp
@@ -102,7 +102,6 @@ void ThermalSoaring::runReachAltitude() {
   if ( mavPos_(2) >= SOAR_ALT_CUTOFF ) {
     std::cout << "State Transition to: STATE_FREE_SOAR from: STATE_REACH_ALTITUDE" << std::endl;
     controller_state_ = CONTROLLER_STATE::STATE_FREE_SOAR;
-    thermal_estimator_.reset();
     //TODO: Reinitialize thermal estimator
     return;
   } else {


### PR DESCRIPTION
This is a hot fix since the estimator was printing out nans.

Todo: Need a better policy on initializing the thermal states and state covariances