### PR TITLE
Add thermal detector

### DIFF
--- a/thermal_soaring/CMakeLists.txt
+++ b/thermal_soaring/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 #############
 # LIBRARIES #
@@ -14,6 +14,7 @@ add_definitions(-std=c++11)
 cs_add_library(${PROJECT_NAME}
   src/thermal_soaring.cpp
   src/thermal_estimator.cpp
+  src/thermal_detector.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
@@ -38,6 +39,7 @@ if(CATKIN_ENABLE_TESTING)
     # Add gtest based cpp test target and link libraries
     catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
                                           test/test_example.cpp
+                                          test/thermal_detector-test.cpp
     )
     if(TARGET ${PROJECT_NAME}-test)
         target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}

--- a/thermal_soaring/include/thermal_soaring/thermal_detector.h
+++ b/thermal_soaring/include/thermal_soaring/thermal_detector.h
@@ -1,0 +1,53 @@
+//  October/2020, Auterion AG, Jaeyoung Lim, jaeyoung@auterion.com
+
+#ifndef THERMAL_DETECTOR_H
+#define THERMAL_DETECTOR_H
+
+#include <ros/ros.h>
+#include <ros/subscribe_options.h>
+#include <tf/transform_broadcaster.h>
+
+#include <stdio.h>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+
+#include <Eigen/Dense>
+#include <math.h>
+
+
+using namespace std;
+using namespace Eigen;
+
+class ThermalDetector
+{
+  private:  
+    //Parameters
+    double K_;
+    const double g_{9.8};
+    double mass_;
+    const double rho_{1.225};
+    double A_wing_;
+    double C_D0_;
+    double C_L_MAX_{5.0};
+    double B_;
+    bool vehicle_in_thermal_;
+    double netto_variometer_;
+
+    //Vehicle State
+    Eigen::Vector3d prev_velocity_;
+
+  protected:
+    double getDragPolarCurve(double airspeed, double bank_angle);
+    double getSpecificEnergyRate(Eigen::Vector3d velocity, Eigen::Vector3d prev_velocity, double dt);
+
+  public:
+    ThermalDetector();
+    virtual ~ThermalDetector();
+    void UpdateState(const Eigen::Vector3d &velocity, const Eigen::Vector4d &attitude);
+    bool IsInThermal(){ return vehicle_in_thermal_;};
+    double getNettoVariometer(){ return netto_variometer_;};
+};
+
+
+#endif

--- a/thermal_soaring/include/thermal_soaring/thermal_estimator.h
+++ b/thermal_soaring/include/thermal_soaring/thermal_estimator.h
@@ -29,19 +29,8 @@ class ThermalEstimator
     ros::Publisher  status_pub_;
   
     //Parameters
-    double K_;
-    const double g_ = 9.8;
-    double mass_;
-    const double rho_ = 1.225;
-    double A_wing_;
-    double C_D0_;
-    double B_;
     double R_;
-    double soaring_threshold_ = 0.1;
 
-
-    //Estimator States
-    bool vehicle_in_thermal_;
     // thermal state vector is defined as below
     // W_th : Thermal Strength
     // R_th : Thermal Radius
@@ -57,9 +46,6 @@ class ThermalEstimator
     Eigen::Matrix4d F_;
     Eigen::Matrix4d Q_;
 
-    double getNettoVariometer(Eigen::Vector3d velocity);
-    double getDragPolarCurve(double airspeed, double bank_angle);
-    double getSpecificEnergyRate(Eigen::Vector3d velocity, Eigen::Vector3d prev_velocity);
     double ObservationFunction(Eigen::Vector4d state);
     Eigen::Vector4d ObservationProcess(Eigen::Vector4d state);
     void PublishEstimatorStatus(Eigen::Vector4d state);
@@ -70,7 +56,6 @@ class ThermalEstimator
     virtual ~ ThermalEstimator();
     void UpdateState(Eigen::Vector3d position, Eigen::Vector3d velocity, Eigen::Vector4d attitude, Eigen::Vector3d wind_velocity);
     void reset();
-    bool IsInThermal();
     Eigen::Vector3d getThermalPosition();
 };
 

--- a/thermal_soaring/include/thermal_soaring/thermal_soaring.h
+++ b/thermal_soaring/include/thermal_soaring/thermal_soaring.h
@@ -18,7 +18,9 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/TwistWithCovarianceStamped.h>
-#include <thermal_soaring/thermal_estimator.h>
+
+#include "thermal_soaring/thermal_estimator.h"
+#include "thermal_soaring/thermal_detector.h"
 
 using namespace std;
 using namespace Eigen;
@@ -74,6 +76,7 @@ class ThermalSoaring
     Eigen::Vector3d wind_velocity_;
 
     ThermalEstimator thermal_estimator_;
+    ThermalDetector thermal_detector_;
 
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);

--- a/thermal_soaring/src/thermal_detector.cpp
+++ b/thermal_soaring/src/thermal_detector.cpp
@@ -1,0 +1,53 @@
+#include "thermal_soaring/thermal_detector.h"
+
+ThermalDetector::ThermalDetector() {
+  //Vehicle Specific Parameters
+  mass_ = 1.5;
+  A_wing_ = 0.3;
+  C_D0_ = 0.067; //SOAR_POLAR_C_D0 0 - 0.5
+  C_L_MAX_ = 5.0;
+  B_ = 0.037;  //SOAR_POLAR_B 0 - 0.5
+
+  K_ = 2 * mass_ * g_ / (rho_ * A_wing_); //SOAR_POLAR_K
+}
+
+ThermalDetector::~ThermalDetector() {
+
+}
+
+void ThermalDetector::UpdateState(const Eigen::Vector3d &velocity, const Eigen::Vector4d &attitude) {
+  //TODO: Infer time differences
+  double dt = 1.0;
+
+  Eigen::Quaterniond q(attitude[0], attitude[1], attitude[2], attitude[3]);
+  Eigen::Vector3d rpy = Eigen::Matrix3d(q).eulerAngles(0, 1, 2);  // RPY
+  double bank_angle = rpy(0);
+
+  //TODO: Get airspeed properly
+  double vz = getDragPolarCurve(velocity.norm(), bank_angle);
+  double e_dot = getSpecificEnergyRate(velocity, prev_velocity_, dt);
+  netto_variometer_ = e_dot + vz;
+  
+  prev_velocity_ = velocity;
+}
+
+double ThermalDetector::getDragPolarCurve(double airspeed, double bank_angle){
+  if (airspeed <= 0.0) {
+      return 0.0;
+  }
+  double C_L = std::min(std::max(K_ / std::pow(airspeed, 2), 0.0), C_L_MAX_);
+  double v_z = airspeed * (C_D0_ / C_L + B_ * C_L / std::pow(cos(bank_angle), 2));
+
+  return v_z;
+}
+
+double ThermalDetector::getSpecificEnergyRate(Eigen::Vector3d velocity, Eigen::Vector3d prev_velocity, double dt){
+  if (dt <= 0) {
+      return 0.0;
+  }
+  double v_dot = (velocity.norm() - prev_velocity.norm()) / dt;
+  double h_dot = velocity(2);
+  double e_dot = h_dot + velocity.norm() * v_dot / g_;
+
+  return e_dot;
+}

--- a/thermal_soaring/src/thermal_soaring.cpp
+++ b/thermal_soaring/src/thermal_soaring.cpp
@@ -8,7 +8,8 @@ using namespace std;
 ThermalSoaring::ThermalSoaring(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
   nh_(nh),
   nh_private_(nh_private),
-  thermal_estimator_(nh, nh_private) {
+  thermal_estimator_(nh, nh_private),
+  thermal_detector_() {
 
   cmdloop_timer_ = nh_.createTimer(ros::Duration(0.01), &ThermalSoaring::cmdloopCallback, this); // Define timer for constant loop rate
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &ThermalSoaring::statusloopCallback, this); // Define timer for constant loop rate
@@ -57,9 +58,12 @@ void ThermalSoaring::statusloopCallback(const ros::TimerEvent& event){
 void ThermalSoaring::runFreeSoar() {
   flight_mode_ = SETPOINT_MODE_SOAR;
 
+  thermal_detector_.UpdateState(mavVel_, mavAtt_);
+  bool found_thermal = thermal_detector_.IsInThermal();
+
   thermal_estimator_.UpdateState(mavPos_, mavVel_, mavAtt_, wind_velocity_);
 
-  bool found_thermal = thermal_estimator_.IsInThermal();
+
 
   //TODO: Check if thermal is reachable
 
@@ -114,7 +118,7 @@ void ThermalSoaring::runThermalSoar() {
   // If altitude is too high, exit thermal
   flight_mode_ = SETPOINT_MODE_SOAR;
 
-  bool is_in_thermal = thermal_estimator_.IsInThermal();
+  bool is_in_thermal = thermal_detector_.IsInThermal();
 
   //Run Thermal estimator when in a thermal
   thermal_estimator_.UpdateState(mavPos_, mavVel_, mavAtt_, wind_velocity_);

--- a/thermal_soaring/test/thermal_detector-test.cpp
+++ b/thermal_soaring/test/thermal_detector-test.cpp
@@ -1,0 +1,58 @@
+#include "thermal_soaring/thermal_detector.h"
+
+#include <gtest/gtest.h>
+#include <memory.h>
+#include <iostream>
+#include <ros/ros.h>
+
+class ThermalDetectorTest : public ThermalDetector, public ::testing::Test {
+ public:
+
+  void SetUp() override {
+    // det = std::make_unique<ThermalDetector>();
+  }
+
+  void TearDown() override {
+
+  }
+};
+
+TEST_F(ThermalDetectorTest, TestSpecificEnergyRate) {
+  //Specific Energy Rate is zero when stationary
+  Eigen::Vector3d velocity = Eigen::Vector3d::Zero();
+  Eigen::Vector3d prev_velocity = Eigen::Vector3d::Zero();
+  EXPECT_NEAR(getSpecificEnergyRate(velocity, prev_velocity, 1.0), 0.0, 0.0001);
+  prev_velocity << 10.0, 0.0, 0.0; //Descending
+  velocity << 10.0, 0.0, -1.0; //Descending
+  //Simultaneuous Querying
+  EXPECT_NEAR(getSpecificEnergyRate(velocity, prev_velocity, 0.0), 0.0, 0.0001);
+  //Wrong timestamp
+  EXPECT_NEAR(getSpecificEnergyRate(velocity, prev_velocity, -1.0), 0.0, 0.0001);
+  //Descending specific energy rate
+  EXPECT_TRUE(getSpecificEnergyRate(velocity, prev_velocity, 1.0) < 0.0);
+  velocity << 10.0, 0.0, 1.0; //Ascending
+  //Ascending specific energy rate
+  EXPECT_TRUE(getSpecificEnergyRate(velocity, prev_velocity, 1.0) > 0.0);
+}
+
+TEST_F(ThermalDetectorTest, TestDragPolarCurve) {
+  //Specific Energy Rate is zero when stationary
+  double airspeed = 0.0;
+  double bank_angle = 0.0;
+  EXPECT_NEAR(getDragPolarCurve(airspeed, bank_angle), 0.0, 0.0001);
+  airspeed = 10.0;
+  bank_angle = 0.0;
+  EXPECT_TRUE(getDragPolarCurve(airspeed, bank_angle) > 0.0);
+  airspeed = 10.0;
+  bank_angle = 0.1;
+  EXPECT_TRUE(getDragPolarCurve(airspeed, bank_angle) > 0.0);
+}
+
+TEST_F(ThermalDetectorTest, TestNettoVariometer) {
+  //Test NettoVariometer when stationary
+  Eigen::Vector3d velocity = Eigen::Vector3d::Zero();
+  Eigen::Vector4d attitude = Eigen::Vector4d::Zero();
+  UpdateState(velocity, attitude);
+  UpdateState(velocity, attitude);
+  EXPECT_NEAR(getNettoVariometer(), 0.0, 0.0001);
+}


### PR DESCRIPTION
**Problem Description**
This PR adds a `thermal_detector` class which contains the netto variometer. This separates the thermal estimator with the thermal detector, since they are independent. For example, the thermal estimator should not be running when the theraml detector hasn't detected a thermal.

**Additional Context**
- This starts to adds proper tests to the project, coverage calculation will folow