### PR TITLE
Test and fix Thermal Estimator

### DIFF
--- a/soaring_msgs/msg/ThermalEstimatorStatus.msg
+++ b/soaring_msgs/msg/ThermalEstimatorStatus.msg
@@ -7,6 +7,7 @@ uint16 status
 uint16 THERMAL_UNKNOWN = 0
 uint16 THERMAL_FIXED = 1
 
+float64 netto_variometer # Netto Variometer
 float64 latitude # Thermal Center lattitude
 float64 longitude # Thermal Center longitude
 float32 altitude # Thermal Center longitude

--- a/thermal_soaring/CMakeLists.txt
+++ b/thermal_soaring/CMakeLists.txt
@@ -40,6 +40,7 @@ if(CATKIN_ENABLE_TESTING)
     catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
                                           test/test_example.cpp
                                           test/thermal_detector-test.cpp
+                                          test/thermal_estimator-test.cpp
     )
     if(TARGET ${PROJECT_NAME}-test)
         target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}

--- a/thermal_soaring/include/thermal_soaring/thermal_estimator.h
+++ b/thermal_soaring/include/thermal_soaring/thermal_estimator.h
@@ -3,10 +3,6 @@
 #ifndef THERMAL_ESTIMATOR_H
 #define THERMAL_ESTIMATOR_H
 
-#include <ros/ros.h>
-#include <ros/subscribe_options.h>
-#include <tf/transform_broadcaster.h>
-
 #include <stdio.h>
 #include <cstdlib>
 #include <string>
@@ -15,19 +11,12 @@
 #include <Eigen/Dense>
 #include <math.h>
 
-#include "soaring_msgs/ThermalEstimatorStatus.h"
-
 using namespace std;
 using namespace Eigen;
 
 class ThermalEstimator
 {
   private:
-    ros::NodeHandle nh_;
-    ros::NodeHandle nh_private_;
-
-    ros::Publisher  status_pub_;
-  
     //Parameters
     double R_;
 
@@ -39,24 +28,21 @@ class ThermalEstimator
     Eigen::Vector4d thermal_state_;
     Eigen::Matrix4d thermal_state_covariance_;
 
-    //Vehicle State
-    Eigen::Vector3d prev_position_;
-    Eigen::Vector3d prev_velocity_;
-
     Eigen::Matrix4d F_;
     Eigen::Matrix4d Q_;
 
-    double ObservationFunction(Eigen::Vector4d state);
-    Eigen::Vector4d ObservationProcess(Eigen::Vector4d state);
-    void PublishEstimatorStatus(Eigen::Vector4d state);
-
+  protected:
+    void ObservationProcess(Eigen::Vector4d state, Eigen::Vector4d &H, double &predicted_measurement);
+    void PriorUpdate(const Eigen::Vector4d &state, const Eigen::Matrix4d &covariance, Eigen::Vector4d &predicted_state, Eigen::Matrix4d &predicted_covariance);
+    void MeasurementUpdate(const Eigen::Vector4d &state, const Eigen::Matrix4d &covariance, Eigen::Vector4d &updated_state, Eigen::Matrix4d &updated_covariance, double measurement);
 
   public:
-    ThermalEstimator(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    ThermalEstimator();
     virtual ~ ThermalEstimator();
-    void UpdateState(Eigen::Vector3d position, Eigen::Vector3d velocity, Eigen::Vector4d attitude, Eigen::Vector3d wind_velocity);
+    void UpdateState(Eigen::Vector3d position, Eigen::Vector3d velocity, Eigen::Vector4d attitude, Eigen::Vector3d wind_velocity, double netto_vario);
     void reset();
     Eigen::Vector3d getThermalPosition();
+    Eigen::Vector4d getThermalState() { return thermal_state_; };
 };
 
 

--- a/thermal_soaring/include/thermal_soaring/thermal_soaring.h
+++ b/thermal_soaring/include/thermal_soaring/thermal_soaring.h
@@ -22,10 +22,14 @@
 #include "thermal_soaring/thermal_estimator.h"
 #include "thermal_soaring/thermal_detector.h"
 
+#include "soaring_msgs/ThermalEstimatorStatus.h"
+#include <mavros_msgs/PositionTarget.h>
+
+
 using namespace std;
 using namespace Eigen;
 
-uint16_t SETPOINT_MODE_SOAR = 0x8000;
+uint16_t SETPOINT_MODE_SOAR = mavros_msgs::PositionTarget::IGNORE_PZ | mavros_msgs::PositionTarget::IGNORE_VZ | mavros_msgs::PositionTarget::IGNORE_AFZ;
 uint16_t SETPOINT_MODE_CRUISE = 0x3000;
 double SOAR_ALT_CUTOFF = 70.0;
 double SOAR_ALT_MAX = 100.0;
@@ -56,6 +60,7 @@ class ThermalSoaring
     ros::NodeHandle nh_private_;
 
     ros::Publisher setpointraw_pub_;
+    ros::Publisher status_pub_;
     ros::Subscriber mavpose_sub_;
     ros::Subscriber mavtwist_sub_;
     ros::Subscriber windest_sub_;
@@ -84,6 +89,7 @@ class ThermalSoaring
     void runReachAltitude();
     void runThermalSoar();
     void PubPositionSetpointRaw();
+    void PublishEstimatorStatus();
     void mavposeCallback(const geometry_msgs::PoseStamped& msg) {
       mavPos_(0) = msg.pose.position.x;
       mavPos_(1) = msg.pose.position.y;

--- a/thermal_soaring/src/thermal_detector.cpp
+++ b/thermal_soaring/src/thermal_detector.cpp
@@ -3,8 +3,8 @@
 ThermalDetector::ThermalDetector() {
   //Vehicle Specific Parameters
   mass_ = 1.5;
-  A_wing_ = 0.3;
-  C_D0_ = 0.067; //SOAR_POLAR_C_D0 0 - 0.5
+  A_wing_ = 1.2;
+  C_D0_ = 0.0067; //SOAR_POLAR_C_D0 0 - 0.5
   C_L_MAX_ = 5.0;
   B_ = 0.037;  //SOAR_POLAR_B 0 - 0.5
 
@@ -27,7 +27,7 @@ void ThermalDetector::UpdateState(const Eigen::Vector3d &velocity, const Eigen::
   double vz = getDragPolarCurve(velocity.norm(), bank_angle);
   double e_dot = getSpecificEnergyRate(velocity, prev_velocity_, dt);
   netto_variometer_ = e_dot + vz;
-  
+
   prev_velocity_ = velocity;
 }
 

--- a/thermal_soaring/src/thermal_estimator.cpp
+++ b/thermal_soaring/src/thermal_estimator.cpp
@@ -5,9 +5,7 @@
 using namespace Eigen;
 using namespace std;
 //Constructor
-ThermalEstimator::ThermalEstimator(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
-  nh_(nh),
-  nh_private_(nh_private) {
+ThermalEstimator::ThermalEstimator() {
 
   F_ = Eigen::Matrix4d::Identity();   //Process Dynamics
 
@@ -18,39 +16,25 @@ ThermalEstimator::ThermalEstimator(const ros::NodeHandle& nh, const ros::NodeHan
   Q_ = Q_vector.asDiagonal();
 
   thermal_state_ << 100.0, 10.0, 0.0, 0.0;
-
-  status_pub_ = nh_.advertise<soaring_msgs::ThermalEstimatorStatus>("/soaring/thermal_estimator/status", 1);
 }
 
 ThermalEstimator::~ThermalEstimator() {
   //Destructor
 }
 
-void ThermalEstimator::UpdateState(Eigen::Vector3d position, Eigen::Vector3d velocity, Eigen::Vector4d attitude, Eigen::Vector3d wind_velocity){
+void ThermalEstimator::UpdateState(Eigen::Vector3d position, Eigen::Vector3d velocity, Eigen::Vector4d attitude, Eigen::Vector3d wind_velocity, double netto_vario){
   //Update States
   Eigen::Vector3d current_position = position;
   Eigen::Vector3d current_velocity = velocity;
 
   //Estimate Thermal states
-  ///State transition
-  Eigen::Vector4d thermal_state_hat = thermal_state_;
-  Eigen::Matrix4d thermal_state_covariance_hat = thermal_state_covariance_ + Q_;
+  ///Prior Update
+  Eigen::Vector4d predicted_thermal_state;
+  Eigen::Matrix4d predicted_thermal_covariance;
+  PriorUpdate(thermal_state_, thermal_state_covariance_, predicted_thermal_state, predicted_thermal_covariance);
 
-  ///Compute Kalman gains
-  Eigen::Vector4d H = ObservationProcess(thermal_state_);
-  double den = H.transpose() * thermal_state_covariance_hat * H + R_;
-  Eigen::Vector4d K_kalman_ = thermal_state_covariance_hat * H / den;
-
-  //Update
-  //FIXME: nettorate
-  double netto_rate;
-  thermal_state_ = thermal_state_hat + K_kalman_ * (netto_rate - ObservationFunction(thermal_state_));
-  thermal_state_covariance_ = (Eigen::Matrix4d::Identity() - K_kalman_ * H.transpose())*thermal_state_covariance_ + Q_;
-
-  prev_position_ = current_position;
-  prev_velocity_ = current_velocity;
-
-  PublishEstimatorStatus(thermal_state_);
+  //MeaurementUpdate
+  MeasurementUpdate(predicted_thermal_state, predicted_thermal_covariance, thermal_state_, thermal_state_covariance_, netto_vario);
 }
 
 void ThermalEstimator::reset() {
@@ -59,43 +43,41 @@ void ThermalEstimator::reset() {
 
 }
 
+void ThermalEstimator::PriorUpdate(const Eigen::Vector4d &state, const Eigen::Matrix4d &covariance, Eigen::Vector4d &predicted_state, Eigen::Matrix4d &predicted_covariance) {
+  predicted_state = state;
+  predicted_covariance = covariance + Q_;
+}
+
+void ThermalEstimator::MeasurementUpdate(const Eigen::Vector4d &state, const Eigen::Matrix4d &covariance, Eigen::Vector4d &updated_state, Eigen::Matrix4d &updated_covariance, double measurement) {
+  ///Compute Kalman gains
+  double predicted_measurement;
+  Eigen::Vector4d H;
+  ObservationProcess(thermal_state_, H, predicted_measurement);
+  double den = H.transpose() * covariance * H + R_;
+  Eigen::Vector4d K_kalman_ = covariance * H / den;
+
+  //Update
+  //TODO: Publish innovations
+  updated_state = state + K_kalman_ * (measurement - predicted_measurement);
+  updated_covariance = (Eigen::Matrix4d::Identity() - K_kalman_ * H.transpose())*covariance + Q_;
+}
+
 Eigen::Vector3d ThermalEstimator::getThermalPosition(){
   Eigen::Vector3d thermal_center;
   thermal_center << thermal_state_(2), thermal_state_(3), 0.0;
   return thermal_center;
 }
 
-Eigen::Vector4d ThermalEstimator::ObservationProcess(Eigen::Vector4d state){
-  Eigen::Vector4d H;
+void ThermalEstimator::ObservationProcess(Eigen::Vector4d state, Eigen::Vector4d &H, double &predicted_measurement){
   const double W_th = state(0);
   const double R_th = state(1);
   const double x = state(2);
   const double y = state(3);
+
+  predicted_measurement = W_th * std::exp( - (x*x + y*y)/(R_th*R_th));
 
   H(0) = std::exp(- (x*x + y*y)/(R_th*R_th));
   H(1) = 2 * W_th * (x*x + y*y) * H(0) / (std::pow(R_th, 3));
   H(2) = 2 * W_th * x * H(0) / (std::pow(R_th, 2));
   H(3) = 2 * W_th * y * H(0) / (std::pow(R_th, 2));
-  
-  return H;
-}
-
-double ThermalEstimator::ObservationFunction(Eigen::Vector4d state){
-  const double W_th = state(0);
-  const double R_th = state(1);
-  const double x = state(2);
-  const double y = state(3);
-
-  return W_th * std::exp( - (x*x + y*y)/(R_th*R_th));
-}
-
-void ThermalEstimator::PublishEstimatorStatus(Eigen::Vector4d state) {
-  soaring_msgs::ThermalEstimatorStatus msg;
-
-  msg.header.stamp = ros::Time::now();
-  msg.position.x = state(2);
-  msg.position.y = state(3);
-  msg.radius = state(1);
-  msg.strength = state(0);
-  status_pub_.publish(msg);
 }

--- a/thermal_soaring/test/thermal_estimator-test.cpp
+++ b/thermal_soaring/test/thermal_estimator-test.cpp
@@ -1,0 +1,36 @@
+#include "thermal_soaring/thermal_estimator.h"
+
+#include <gtest/gtest.h>
+#include <memory.h>
+#include <iostream>
+#include <ros/ros.h>
+
+class ThermalEstimatorTest : public ThermalEstimator, public ::testing::Test {
+ public:
+
+  void SetUp() override {
+
+  }
+
+  void TearDown() override {
+
+  }
+};
+
+TEST_F(ThermalEstimatorTest, TestPriorUpdate) {
+  Eigen::Vector4d state, predicted_state;
+  Eigen::Matrix4d covariance, predicted_covariance;
+
+  //No particular update in prior updates
+  PriorUpdate(state, covariance, predicted_state, predicted_covariance);
+  EXPECT_TRUE(state.isApprox(predicted_state));
+}
+
+TEST_F(ThermalEstimatorTest, TestMeasurementUpdate) {
+  Eigen::Vector4d state, predicted_state;
+  EXPECT_TRUE(true);
+}
+
+TEST_F(ThermalEstimatorTest, ObservationProcess) {
+  EXPECT_TRUE(true);
+}


### PR DESCRIPTION
**Problem Description**
This commit adds testing to the thermal estimator and fixes the underlying issues with the estimator.

Fixes include the following
- Fix `type_mask` for the soaring setpoints using enums
- Tune `variometer` for detecting thermals
- Move estimator status publishing to the thermal soaring class
- This adds unit tests and removes the ROS dependency to the `thermal_estimator`

**Additional Context**
