### PR TITLE
Fix trajectory fourier coefficient

### DIFF
--- a/ergodic_soaring/include/ergodic_soaring/fourier_coefficient.h
+++ b/ergodic_soaring/include/ergodic_soaring/fourier_coefficient.h
@@ -60,7 +60,7 @@ class FourierCoefficient {
   virtual ~FourierCoefficient(){};
   grid_map::GridMap &getGridMap() { return grid_map_; };
   void FourierTransform(grid_map::GridMap &distribution_map);
-  void FourierTransform(std::vector<State> trajectory);
+  void FourierTransform(const std::vector<State> &trajectory);
   void InverseFourierTransform(const std::string layer);
   void setGridMap(grid_map::GridMap &grid_map) { grid_map_ = grid_map; };
   Eigen::ArrayXXd getCoefficients() { return coefficients_; };

--- a/ergodic_soaring/src/test_ergodic_map_node.cpp
+++ b/ergodic_soaring/src/test_ergodic_map_node.cpp
@@ -48,7 +48,7 @@ void generateGaussianDistribution(grid_map::GridMap &grid_map) {
     grid_map.getPosition(gridMapIndex, cell_pos);
 
     double sigma = 5.0;
-    grid_map::Position mean = Eigen::Vector2d::Zero();
+    grid_map::Position mean = Eigen::Vector2d(5.0, 5.0);
     Eigen::Matrix2d variance = sigma * Eigen::Matrix2d::Identity();
     Eigen::Vector2d error_pos = cell_pos - mean;
     double point_distribution = 1 / (std::sqrt(std::pow(2 * M_PI, 2) * variance.norm())) *
@@ -90,8 +90,8 @@ int main(int argc, char **argv) {
   settings.delta_easting = 10.0;
   settings.delta_northing = 10.0;
   grid_map_.setFrameId("world");
-  grid_map_.setGeometry(grid_map::Length(settings.delta_easting, settings.delta_northing), settings.resolution,
-                        grid_map::Position(settings.center_lat, settings.center_lon));
+  double resolution = 0.1;
+  grid_map_.setGeometry(grid_map::Length(10.0, 10.0), resolution, grid_map::Position(5.0, 5.0));
 
   generateGaussianDistribution(grid_map_);
 


### PR DESCRIPTION
**Problem Description**
This PR fixes the trajectory fourier transform by shifting the domain from [-L, L] to [0, 2L]
Otherwise it was observed that there can be mirroring effects with the previous formulation
- Before PR:
![image](https://user-images.githubusercontent.com/5248102/147884877-f8a4f4cd-abbf-47ef-8935-a4f14eb03773.png)

- After PR:
![image](https://user-images.githubusercontent.com/5248102/147884930-a6241afe-7ac8-41d6-ac1f-cd07311f82af.png)

This is required to fix the problem with the normalization of the reconstructed distribution of trajectories

**Additional Context**
- The sum of the reconstructed probability distribution is still not 1.0, but rather close to zero
```
Reconstruction Fourier====================
  - Sum of distribution: -4.00548e-15
```